### PR TITLE
Set xt_mode to true for Test::Compile plugin

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -30,6 +30,7 @@ skip = ^DateTime
 [Test::ChangesHasContent]
 [PodSyntaxTests]
 [Test::Compile]
+  xt_mode = 1
 [Test::ReportPrereqs]
 [AssertOS]
   os = MSWin32


### PR DESCRIPTION
This should fix the issue where the compilation test fails when DT::TZ is not installed yet.
